### PR TITLE
fix: initialize gpio_keys input from pin state

### DIFF
--- a/drivers/input/input_gpio_keys.c
+++ b/drivers/input/input_gpio_keys.c
@@ -137,7 +137,7 @@ static int gpio_keys_interrupt_configure(const struct gpio_dt_spec *gpio_spec,
 		return ret;
 	}
 
-	cb->pin_state = -1;
+	cb->pin_state = gpio_pin_get_dt(gpio_spec);
 
 	LOG_DBG("port=%s, pin=%d", gpio_spec->port->name, gpio_spec->pin);
 


### PR DESCRIPTION
Some kind of race condition caused the gpio_keys input module to occasionally miss an event after boot. This is fixed by initializing the pin state variable in the input_gpio_keys module.

Related to https://github.com/starcopter/bms-firmware/issues/6